### PR TITLE
Alternate way to call blocks defined on Multiblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ To make it work, let's define `process` method in following way:
       # do actual processing...
 
       if result == "success"
-        multiblock.call(:success)
+        multiblock.success
       else
-        multiblock.call(:failure)
+        multiblock.failure
       end
     end
 

--- a/lib/multiblock.rb
+++ b/lib/multiblock.rb
@@ -8,7 +8,7 @@ class Multiblock < BlankSlate
   end
 
   def method_missing(name, *args, &blk)
-    raise ArgumentError.new("No block given when registering '#{name}' block.") unless block_given?
+    return call(name, *args) unless block_given?
     @blocks[name.to_s] = blk
   end
 

--- a/spec/multiblock_spec.rb
+++ b/spec/multiblock_spec.rb
@@ -34,7 +34,7 @@ describe Multiblock do
   end
 
   it "should call the previously defined block if called without a block" do
-    multiblock.foo { |arg| arg }
+    multiblock.bar { |arg| arg }
     expect( multiblock.bar("foo") ).to eq("foo")
   end
 

--- a/spec/multiblock_spec.rb
+++ b/spec/multiblock_spec.rb
@@ -29,10 +29,13 @@ describe Multiblock do
     multiblock.call(:foo, "foo").should == "foo"
   end
 
-  it "should raise ArgumentError exception when registering without block" do
-    lambda {
-      multiblock.foo
-    }.should raise_exception(ArgumentError, "No block given when registering 'foo' block.")
+  it "should return the default when calling without a previously defined block" do
+    expect( multiblock.bar ).to eq(nil)
+  end
+
+  it "should call the previously defined block if called without a block" do
+    multiblock.foo { |arg| arg }
+    expect( multiblock.bar("foo") ).to eq("foo")
   end
 
   context "with custom default block" do


### PR DESCRIPTION
Instead of raising an exception, why not use method_missing as a convenient way to call the defined methods
